### PR TITLE
feat: allow STD I2S stereo dual-mic without TDM

### DIFF
--- a/docs/esp_audio_stack.rst
+++ b/docs/esp_audio_stack.rst
@@ -84,6 +84,9 @@ Core audio:
   ``left`` or ``right``. Defaults to ``left``.
 - **rx_slot_mode** (*Optional*, string): Read one or both stereo slots on RX, ``mono`` or ``stereo``.
   Defaults to ``mono``.
+- **rx_mic_slots** (*Optional*, list): Two STD Philips slots as microphones, ``left`` and/or ``right``.
+  Requires ``rx_slot_mode: stereo``. Omit it to keep single-mic capture via ``mic_channel``.
+  Not an ES8311 DAC-feedback mode; use ``tdm_mic_slots`` on TDM.
 - **tx_channel** (*Optional*, string): TX slot placement in mono-on-stereo layouts, ``left`` or ``right``.
   Defaults to ``left``.
 - **correct_dc_offset** (*Optional*, boolean): Remove DC bias from the capture path. Defaults to ``false``.

--- a/docs/esp_audio_stack.rst
+++ b/docs/esp_audio_stack.rst
@@ -84,9 +84,12 @@ Core audio:
   ``left`` or ``right``. Defaults to ``left``.
 - **rx_slot_mode** (*Optional*, string): Read one or both stereo slots on RX, ``mono`` or ``stereo``.
   Defaults to ``mono``.
-- **rx_mic_slots** (*Optional*, list): Two STD Philips slots as microphones, ``left`` and/or ``right``.
-  Requires ``rx_slot_mode: stereo``. Omit it to keep single-mic capture via ``mic_channel``.
-  Not an ES8311 DAC-feedback mode; use ``tdm_mic_slots`` on TDM.
+- **rx_mic_slots** (*Optional*, list): Exactly two distinct STD Philips slots, ``left`` and
+  ``right`` (duplicates are rejected). List order is the AFE channel order: the first slot
+  is the primary mic (also copied into the mono ``microphone:`` buffer), the second is the
+  secondary. Overlay ``[right, left]`` if BSS is inverted. Requires ``rx_slot_mode: stereo``.
+  Omit it to keep single-mic capture via ``mic_channel``. Not an ES8311 DAC-feedback mode;
+  use ``tdm_mic_slots`` on TDM.
 - **tx_channel** (*Optional*, string): TX slot placement in mono-on-stereo layouts, ``left`` or ``right``.
   Defaults to ``left``.
 - **correct_dc_offset** (*Optional*, boolean): Remove DC bias from the capture path. Defaults to ``false``.

--- a/esphome/components/esp_audio_stack/README.md
+++ b/esphome/components/esp_audio_stack/README.md
@@ -169,7 +169,7 @@ Two MEMS on one Philips data line (SEL strapped L/R, no codec, no TDM) keep
 ```yaml
 esp_audio_stack:
   rx_slot_mode: stereo
-  rx_mic_slots: [left, right]  # both STD slots; omit this for single-mic
+  rx_mic_slots: [left, right]  # order = AFE ch0/ch1; first is also the mono mic
   correct_dc_offset: true      # per-channel HPFs, not one filter across L/R
   processor_id: afe            # esp_afe mic_num: 2, se_enabled: true
 ```
@@ -390,7 +390,7 @@ First-version limits:
 | `correct_dc_offset` | bool | false | Enable DC offset removal. Required for MEMS mics without built-in HPF (MSM261, SPH0645). |
 | `mic_channel` | string | `left` | Which STD slot carries the microphone: `left` or `right`. In mono RX mode this becomes the IDF slot mask. With `rx_slot_mode: stereo`, both STD slots are read and this selects the slot in software. |
 | `rx_slot_mode` | string | `mono` | `mono` reads only `mic_channel`. `stereo` reads both STD RX slots and then selects `mic_channel`; useful for MEMS mics strapped to L/R where the wire behaves better as a full stereo frame. This is not an AEC reference mode. |
-| `rx_mic_slots` | list | - | STD dual-mic: exactly two of `left`/`right`. Requires `rx_slot_mode: stereo`. Omit it to keep single-mic (`mic_channel` picks one slot). Mutually exclusive with TDM slots and `use_stereo_aec_reference`. Pair with `esp_afe` `mic_num: 2`. |
+| `rx_mic_slots` | list | - | STD dual-mic: exactly two distinct `left`/`right` values. Order is AFE channel order (first = primary/mono mic, second = secondary). Requires `rx_slot_mode: stereo`. Omit it to keep single-mic (`mic_channel` picks one slot). Mutually exclusive with TDM slots and `use_stereo_aec_reference`. Pair with `esp_afe` `mic_num: 2`. |
 | `use_stereo_aec_reference` | bool | false | ES8311 digital feedback mode (see below) |
 | `reference_channel` | string | left | Which stereo channel carries AEC reference: `left` or `right` |
 | `use_tdm_reference` | bool | false | TDM hardware reference mode (ES7210, see below) |

--- a/esphome/components/esp_audio_stack/README.md
+++ b/esphome/components/esp_audio_stack/README.md
@@ -132,7 +132,7 @@ and gain. These are the knobs users most often need when building a new target:
 | `codec.input` / `codec.output` | Select `es7210`, `es8311`, `es8388`, `es8374` or `es8389` through `esp_codec_dev`. |
 | `rx_bus` / `tx_bus` | Use separate I2S controllers for discrete mic and amplifier. |
 | `bits_per_sample` / `slot_bit_width` | Required for 24/32-bit codecs and 32-bit MEMS microphones. |
-| `mic_channel` / `rx_slot_mode` | Select the actual MEMS mic slot. `rx_slot_mode: stereo` reads both STD slots and then selects `mic_channel` in software. |
+| `mic_channel` / `rx_slot_mode` / `rx_mic_slots` | Select the actual MEMS mic slot. `rx_slot_mode: stereo` reads both STD slots and then selects `mic_channel` in software. `rx_mic_slots: [left, right]` keeps both slots as mics for dual-mic AFE. |
 | `num_channels` / `speaker_channels` / `tx_channel` | Separate physical TX bus layout from public mono/stereo speaker behavior. |
 | `processor_id` | Attach `esp_aec` or `esp_afe`. Omit it for raw full-duplex audio. |
 | `aec_reference` / `aec_reference_buffer_ms` | Tune software AEC reference storage for no-codec boards. |
@@ -162,6 +162,23 @@ esp_audio_stack:
   mic_channel: right   # or left
   rx_slot_mode: stereo # read both STD slots, then pick mic_channel
 ```
+
+Two MEMS on one Philips data line (SEL strapped L/R, no codec, no TDM) keep
+`rx_slot_mode: stereo` and add `rx_mic_slots`. Default remains one mic:
+
+```yaml
+esp_audio_stack:
+  rx_slot_mode: stereo
+  rx_mic_slots: [left, right]  # both STD slots; omit this for single-mic
+  correct_dc_offset: true      # per-channel HPFs, not one filter across L/R
+  processor_id: afe            # esp_afe mic_num: 2, se_enabled: true
+```
+
+Do not set `use_stereo_aec_reference` for a second MEMS; that flag is ES8311
+DAC feedback. `esp_aec` stays mono-reference. Dual-mic BSS uses `esp_afe`,
+which consumes the same interleaved `processor_mic_buffer` layout as TDM
+`tdm_mic_slots`. The public `microphone:` surface stays 16-bit mono
+(post-AFE).
 
 This is intentionally different from `use_stereo_aec_reference`: stereo slot
 mode is only for mic slot selection; the AEC reference still comes from the
@@ -373,6 +390,7 @@ First-version limits:
 | `correct_dc_offset` | bool | false | Enable DC offset removal. Required for MEMS mics without built-in HPF (MSM261, SPH0645). |
 | `mic_channel` | string | `left` | Which STD slot carries the microphone: `left` or `right`. In mono RX mode this becomes the IDF slot mask. With `rx_slot_mode: stereo`, both STD slots are read and this selects the slot in software. |
 | `rx_slot_mode` | string | `mono` | `mono` reads only `mic_channel`. `stereo` reads both STD RX slots and then selects `mic_channel`; useful for MEMS mics strapped to L/R where the wire behaves better as a full stereo frame. This is not an AEC reference mode. |
+| `rx_mic_slots` | list | - | STD dual-mic: exactly two of `left`/`right`. Requires `rx_slot_mode: stereo`. Omit it to keep single-mic (`mic_channel` picks one slot). Mutually exclusive with TDM slots and `use_stereo_aec_reference`. Pair with `esp_afe` `mic_num: 2`. |
 | `use_stereo_aec_reference` | bool | false | ES8311 digital feedback mode (see below) |
 | `reference_channel` | string | left | Which stereo channel carries AEC reference: `left` or `right` |
 | `use_tdm_reference` | bool | false | TDM hardware reference mode (ES7210, see below) |

--- a/esphome/components/esp_audio_stack/__init__.py
+++ b/esphome/components/esp_audio_stack/__init__.py
@@ -54,6 +54,7 @@ CONF_SLOT_BIT_WIDTH = "slot_bit_width"
 CONF_CORRECT_DC_OFFSET = "correct_dc_offset"
 CONF_MIC_CHANNEL = "mic_channel"
 CONF_RX_SLOT_MODE = "rx_slot_mode"
+CONF_RX_MIC_SLOTS = "rx_mic_slots"
 CONF_I2S_MODE = "i2s_mode"
 CONF_USE_APLL = "use_apll"
 CONF_I2S_NUM = "i2s_num"
@@ -309,6 +310,25 @@ def _validate_tdm_config(config):
     return config
 
 
+def _validate_rx_mic_slots(config):
+    """STD I2S dual-mic: two Philips slots, not TDM and not ES8311 DAC feedback."""
+    if CONF_RX_MIC_SLOTS not in config:
+        return config
+    if config.get(CONF_RX_SLOT_MODE, "mono") != "stereo":
+        raise cv.Invalid("rx_mic_slots requires rx_slot_mode: stereo")
+    if config.get(CONF_USE_STEREO_AEC_REFERENCE, False):
+        raise cv.Invalid(
+            "rx_mic_slots is two MEMS on STD I2S; use_stereo_aec_reference is "
+            "ES8311 DAC feedback, not a second microphone"
+        )
+    if config.get(CONF_USE_TDM_REFERENCE, False) or CONF_TDM_MIC_SLOTS in config:
+        raise cv.Invalid("rx_mic_slots is STD I2S only; use tdm_mic_slots on TDM")
+    slots = config[CONF_RX_MIC_SLOTS]
+    if slots[0] == slots[1]:
+        raise cv.Invalid("rx_mic_slots must not contain duplicates")
+    return config
+
+
 def _validate_pcm_format(config):
     """Validate that PCM short/long formats require TDM mode."""
     fmt = config.get(CONF_I2S_COMM_FMT, "philips")
@@ -397,6 +417,12 @@ CONFIG_SCHEMA = cv.All(
             ),
             cv.Optional(CONF_RX_SLOT_MODE, default="mono"): cv.one_of(
                 "mono", "stereo", lower=True
+            ),
+            # Two STD Philips slots as mics (e.g. dual SPH0645 on one data line).
+            # Default remains single-mic: omit this and keep mic_channel.
+            cv.Optional(CONF_RX_MIC_SLOTS): cv.All(
+                cv.ensure_list(cv.one_of("left", "right", lower=True)),
+                cv.Length(min=2, max=2),
             ),
             cv.Optional(CONF_TX_CHANNEL, default="left"): cv.one_of(
                 "left", "right", lower=True
@@ -531,6 +557,7 @@ CONFIG_SCHEMA = cv.All(
     ).extend(cv.COMPONENT_SCHEMA),
     _validate_sample_rates,
     _validate_tdm_config,
+    _validate_rx_mic_slots,
     _validate_pcm_format,
     _validate_dual_bus_config,
 )
@@ -593,6 +620,21 @@ def _final_validate(config):
             "Use esp_afe (full AFE pipeline with AEC+NS+AGC+Speech Enhancement) "
             "or esp_aec (standalone echo cancellation), not both."
         )
+
+    afe_conf = full_config.get("esp_afe")
+    if isinstance(afe_conf, list):
+        afe_conf = afe_conf[0] if afe_conf else {}
+    afe_mics = afe_conf.get("mic_num", 1) if isinstance(afe_conf, dict) else 1
+    if afe_mics >= 2:
+        tdm_dual = (
+            config.get(CONF_USE_TDM_REFERENCE, False) or CONF_TDM_MIC_SLOTS in config
+        ) and len(config.get(CONF_TDM_MIC_SLOTS, [])) >= 2
+        std_dual = len(config.get(CONF_RX_MIC_SLOTS, [])) >= 2
+        if not tdm_dual and not std_dual:
+            raise cv.Invalid(
+                "esp_afe mic_num: 2 requires tdm_mic_slots with two slots, "
+                "or rx_slot_mode: stereo plus rx_mic_slots: [left, right]"
+            )
 
     return config
 
@@ -722,6 +764,11 @@ async def to_code(config):
     # Mic channel selection (for mono RX: which I2S slot to capture)
     cg.add(var.set_mic_channel_right(config[CONF_MIC_CHANNEL] == "right"))
     cg.add(var.set_rx_slot_mode_stereo(config[CONF_RX_SLOT_MODE] == "stereo"))
+    if CONF_RX_MIC_SLOTS in config:
+        slot_index = {"left": 0, "right": 1}
+        slots = [slot_index[name] for name in config[CONF_RX_MIC_SLOTS]]
+        cg.add(var.set_std_mic_slots(slots[0], slots[1]))
+        cg.add(var.set_mic_channel_right(slots[0] == 1))
 
     # TX channel selection (for mono TX: which I2S slot to output)
     cg.add(var.set_tx_slot_right(config[CONF_TX_CHANNEL] == "right"))

--- a/esphome/components/esp_audio_stack/audio_pipeline.cpp
+++ b/esphome/components/esp_audio_stack/audio_pipeline.cpp
@@ -141,11 +141,11 @@ bool ESPAudioStack::allocate_audio_buffers_(AudioTaskCtx &ctx) {
   const uint32_t buf_caps =
       this->buffers_in_psram_ ? (MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) : (MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
 
-  // Worst-case processor mic channels: 2 if dual-mic TDM is available, else 1.
-  // Allocating for 2ch unconditionally when dual-mic is possible lets the task
-  // flip between MR (1 mic) and MMR (2 mic) without reallocating on
-  // reconfigure.
-  const uint8_t worst_mic_ch = (this->tdm_second_mic_slot_ >= 0) ? 2 : 1;
+  // Worst-case processor mic channels: 2 if dual-mic TDM or STD stereo slots
+  // are configured, else 1. Allocating for 2ch unconditionally when dual-mic
+  // is possible lets the task flip between MR (1 mic) and MMR (2 mic) without
+  // reallocating on reconfigure.
+  const uint8_t worst_mic_ch = (this->tdm_second_mic_slot_ >= 0 || this->std_second_mic_slot_ >= 0) ? 2 : 1;
   bool processor_buffers_needed = false;
 #ifdef USE_AUDIO_PROCESSOR
   // Allocate for the processor once its frame shape is known, even if AFE
@@ -187,7 +187,7 @@ bool ESPAudioStack::allocate_audio_buffers_(AudioTaskCtx &ctx) {
     bool ready = true;
     bool rx_prepared = false;
 #ifdef USE_ESP_AUDIO_STACK_MULTI_RX
-    if (ctx.use_tdm_bus || ctx.use_stereo_aec_ref) {
+    if (ctx.use_tdm_bus || ctx.use_stereo_aec_ref || ctx.rx_slot_mode_stereo) {
       ready = this->rx_rate_converter_.prepare(ctx.bus_frame_size, ctx.input_frame_size, ctx.rx_rate_converter_channels,
                                                ctx.use_tdm_bus ? ctx.tdm_total_slots : 2, ctx.i2s_bps == 4);
       rx_prepared = true;
@@ -553,6 +553,8 @@ bool ESPAudioStack::prepare_audio_context_(AudioTaskCtx &ctx, bool require_proce
   ctx.speaker_channels = this->get_speaker_channels();
   ctx.use_stereo_aec_ref = this->use_stereo_aec_ref_;
   ctx.rx_slot_mode_stereo = this->rx_slot_mode_stereo_;
+  ctx.std_primary_mic_slot = this->std_primary_mic_slot_;
+  ctx.std_second_mic_slot = this->std_second_mic_slot_;
   ctx.use_tdm_bus = this->use_tdm_bus_;
   ctx.use_tdm_ref = this->use_tdm_ref_;
   ctx.ref_channel_right = this->ref_channel_right_;
@@ -599,9 +601,16 @@ bool ESPAudioStack::prepare_audio_context_(AudioTaskCtx &ctx, bool require_proce
 #ifdef USE_ESP_AUDIO_STACK_MULTI_RX
   // Init multi-channel RX rate converter now that we know channel count
   if (ctx.use_tdm_bus || ctx.use_stereo_aec_ref || ctx.rx_slot_mode_stereo) {
-    ctx.rx_rate_converter_channels =
-        ctx.use_tdm_bus ? (ctx.processor_mic_channels > 1 ? 2 : 1) + (ctx.use_tdm_ref ? 1 : 0)
-                        : (ctx.use_stereo_aec_ref ? 2 : 1);  // stereo ref: mic + ref; stereo mic: selected mic only
+    if (ctx.use_tdm_bus) {
+      ctx.rx_rate_converter_channels =
+          (ctx.processor_mic_channels > 1 ? 2 : 1) + (ctx.use_tdm_ref ? 1 : 0);
+    } else if (ctx.use_stereo_aec_ref) {
+      ctx.rx_rate_converter_channels = 2;  // mic + DAC feedback ref
+    } else if (ctx.processor_mic_channels > 1 && ctx.std_second_mic_slot >= 0) {
+      ctx.rx_rate_converter_channels = 2;  // both STD Philips slots as mics
+    } else {
+      ctx.rx_rate_converter_channels = 1;  // stereo frame, one selected mic
+    }
     this->rx_rate_converter_.init(ctx.ratio, ctx.rx_rate_converter_channels, this->sample_rate_,
                                   this->get_output_sample_rate(), this->rate_cvt_complexity_,
                                   this->rate_cvt_perf_type_);
@@ -706,13 +715,10 @@ void ESPAudioStack::audio_session_() {
     ESP_LOGD(TAG, "Audio session ended");
     return;
   }
-  if (ctx.processor_mic_channels > 1 && !ctx.use_tdm_bus) {
-    alloc_fail("dual-mic processor requires TDM microphone slots");
-    ESP_LOGD(TAG, "Audio session ended");
-    return;
-  }
-  if (ctx.processor_mic_channels > 1 && ctx.tdm_second_mic_slot < 0) {
-    alloc_fail("dual-mic processor requires tdm_mic_slots with two slots");
+  const bool have_tdm_dual_mic = ctx.use_tdm_bus && ctx.tdm_second_mic_slot >= 0;
+  const bool have_std_dual_mic = ctx.rx_slot_mode_stereo && ctx.std_second_mic_slot >= 0;
+  if (ctx.processor_mic_channels > 1 && !have_tdm_dual_mic && !have_std_dual_mic) {
+    alloc_fail("dual-mic processor requires TDM microphone slots or STD rx_mic_slots");
     ESP_LOGD(TAG, "Audio session ended");
     return;
   }
@@ -1111,6 +1117,31 @@ bool ESPAudioStack::process_rx_stereo_ref_(AudioTaskCtx &ctx) {
 
 #ifdef USE_ESP_AUDIO_STACK_MULTI_RX
 bool ESPAudioStack::process_rx_stereo_slot_(AudioTaskCtx &ctx) {
+  // SPH0645 (and similar MEMS) emit 32-bit Philips I2S slots. Dual-mic keeps
+  // per-channel DC (dc_primary_ / dc_secondary_) after deinterleave -- never
+  // one HPF across interleaved L,R,L,R (that becomes an L-R canceller).
+  const bool dual_mic = ctx.processor_mic_channels > 1 && ctx.std_second_mic_slot >= 0;
+  if (dual_mic) {
+    uint8_t ch_offsets[2] = {ctx.std_primary_mic_slot, static_cast<uint8_t>(ctx.std_second_mic_slot)};
+    if (ctx.rx_rate_converter_channels != 2) {
+      this->fail_audio_session_("stereo dual-mic RX channel map");
+      return false;
+    }
+    const bool ok = ctx.i2s_bps == 4
+                        ? this->rx_rate_converter_.process_multi_32(
+                              reinterpret_cast<const int32_t *>(ctx.rx_buffer), ctx.input_frame_size, 2, ch_offsets,
+                              ctx.processor_mic_buffer, ctx.mic_buffer, nullptr, 2)
+                        : this->rx_rate_converter_.process_multi(ctx.rx_buffer, ctx.input_frame_size, 2, ch_offsets,
+                                                                 ctx.processor_mic_buffer, ctx.mic_buffer, nullptr, 2);
+    if (!ok) {
+      this->fail_audio_session_(ctx.i2s_bps == 4 ? "stereo dual-mic RX 32-bit audio-effects conversion"
+                                                 : "stereo dual-mic RX audio-effects conversion");
+      return false;
+    }
+    ctx.processor_input = ctx.processor_mic_buffer;
+    return true;
+  }
+
   const uint8_t mic_offset = this->mic_channel_right_ ? 1 : 0;
   uint8_t ch_offsets[1] = {mic_offset};
   const bool ok = ctx.i2s_bps == 4
@@ -1162,7 +1193,9 @@ void ESPAudioStack::apply_input_conditioning_(AudioTaskCtx &ctx) {
   // boost is needed. Pure input attenuation uses esp-audio-libs Q31 below.
   // For dual-mic: mic1 is in mic_buffer, mic2 is in processor_mic_buffer[i*2+1]
   // (both filled by the multi-channel rate converter). Apply DC+input gain on
-  // both, update in-place. When neither DC nor input gain is needed,
+  // both, update in-place. SPH0645 32-bit slots must use these per-channel
+  // HPFs (dc_primary_ / dc_secondary_); a single delay line over interleaved
+  // L,R,L,R becomes an L-R canceller. When neither DC nor input gain is needed,
   // processor_mic_buffer (dual_mic case) is left as-is: the multi-channel rate
   // converter has already produced correct values for both mics.
   const bool do_dc = ctx.correct_dc_offset;

--- a/esphome/components/esp_audio_stack/esp_audio_stack.cpp
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.cpp
@@ -520,6 +520,10 @@ void ESPAudioStack::dump_config() {
   ESP_LOGCONFIG(TAG, "  Speaker Stream Channels: %u", this->get_speaker_channels());
   ESP_LOGCONFIG(TAG, "  RX Mic Channel: %s", this->mic_channel_right_ ? "RIGHT" : "LEFT");
   ESP_LOGCONFIG(TAG, "  RX Slot Mode: %s", this->rx_slot_mode_stereo_ ? "stereo" : "mono");
+  if (this->std_second_mic_slot_ >= 0) {
+    ESP_LOGCONFIG(TAG, "  RX Mic Slots: [%u,%d] (STD dual-mic)", this->std_primary_mic_slot_,
+                  this->std_second_mic_slot_);
+  }
   static const char *const FMT_NAMES[] = {"Philips", "MSB", "PCM Short", "PCM Long"};
   ESP_LOGCONFIG(TAG, "  Comm Format: %s", FMT_NAMES[this->i2s_comm_fmt_ & 3]);
   ESP_LOGCONFIG(TAG, "  MCLK Multiple: %u", (unsigned) this->mclk_multiple_);

--- a/esphome/components/esp_audio_stack/esp_audio_stack.cpp
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.cpp
@@ -521,8 +521,8 @@ void ESPAudioStack::dump_config() {
   ESP_LOGCONFIG(TAG, "  RX Mic Channel: %s", this->mic_channel_right_ ? "RIGHT" : "LEFT");
   ESP_LOGCONFIG(TAG, "  RX Slot Mode: %s", this->rx_slot_mode_stereo_ ? "stereo" : "mono");
   if (this->std_second_mic_slot_ >= 0) {
-    ESP_LOGCONFIG(TAG, "  RX Mic Slots: [%u,%d] (STD dual-mic)", this->std_primary_mic_slot_,
-                  this->std_second_mic_slot_);
+    ESP_LOGCONFIG(TAG, "  RX Mic Slots: [%u,%d] (STD dual-mic)", (unsigned) this->std_primary_mic_slot_,
+                  (int) this->std_second_mic_slot_);
   }
   static const char *const FMT_NAMES[] = {"Philips", "MSB", "PCM Short", "PCM Long"};
   ESP_LOGCONFIG(TAG, "  Comm Format: %s", FMT_NAMES[this->i2s_comm_fmt_ & 3]);

--- a/esphome/components/esp_audio_stack/esp_audio_stack.h
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.h
@@ -223,6 +223,12 @@ class ESPAudioStack final : public Component {
   void set_i2s_comm_fmt(uint8_t fmt) { this->i2s_comm_fmt_ = fmt; }
   void set_mic_channel_right(bool right) { this->mic_channel_right_ = right; }
   void set_rx_slot_mode_stereo(bool stereo) { this->rx_slot_mode_stereo_ = stereo; }
+  // STD Philips dual-mic: primary/secondary slot indices (0=left, 1=right).
+  // secondary < 0 keeps single-mic stereo-slot mode (mic_channel picks one).
+  void set_std_mic_slots(uint8_t primary, int8_t secondary) {
+    this->std_primary_mic_slot_ = primary;
+    this->std_second_mic_slot_ = secondary;
+  }
   void set_tx_slot_right(bool right) { this->tx_slot_right_ = right; }
   void set_slot_bit_width(uint8_t sbw) { this->slot_bit_width_ = sbw; }
 #ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
@@ -474,6 +480,8 @@ class ESPAudioStack final : public Component {
     uint8_t num_ch{1};   // TX channels
     bool use_stereo_aec_ref{false};
     bool rx_slot_mode_stereo{false};
+    uint8_t std_primary_mic_slot{0};
+    int8_t std_second_mic_slot{-1};
     bool use_tdm_bus{false};
     bool use_tdm_ref{false};
     bool ref_channel_right{false};
@@ -654,6 +662,8 @@ class ESPAudioStack final : public Component {
   uint8_t i2s_comm_fmt_{0};            // 0=philips, 1=msb, 2=pcm_short, 3=pcm_long
   bool mic_channel_right_{false};      // RX mono slot: false=LEFT, true=RIGHT
   bool rx_slot_mode_stereo_{false};    // STD RX reads both slots; mic_channel selects one in software
+  uint8_t std_primary_mic_slot_{0};    // STD dual-mic primary slot (0=left, 1=right)
+  int8_t std_second_mic_slot_{-1};     // STD dual-mic secondary slot; -1 = single mic
   bool tx_slot_right_{false};          // TX mono slot: false=LEFT (default), true=RIGHT
   uint8_t slot_bit_width_{0};          // 0 = auto (match bits_per_sample), or 16/24/32
   uint32_t output_sample_rate_{0};     // 0 = use sample_rate_ (no rate conversion)

--- a/tests/components/esp_audio_stack/test.esp32-s3-std-dual-mic-idf.yaml
+++ b/tests/components/esp_audio_stack/test.esp32-s3-std-dual-mic-idf.yaml
@@ -1,0 +1,52 @@
+# Codec-less STD I2S dual-mic: two MEMS on one Philips data line.
+# Single-mic remains rx_slot_mode: stereo + mic_channel without rx_mic_slots.
+esphome:
+  name: test-esp-audio-stack-std-dual-mic
+
+esp32:
+  board: esp32-s3-devkitc-1
+  variant: esp32s3
+  framework:
+    type: esp-idf
+
+psram:
+  mode: octal
+  speed: 80MHz
+
+esp_afe:
+  id: afe_processor
+  type: sr
+  mode: low_cost
+  mic_num: 2
+  se_enabled: true
+  aec_enabled: true
+  ns_enabled: false
+  vad_enabled: false
+  agc_enabled: false
+
+esp_audio_stack:
+  id: audio_stack
+  processor_id: afe_processor
+  sample_rate: 48000
+  output_sample_rate: 16000
+  bits_per_sample: 32
+  slot_bit_width: 32
+  correct_dc_offset: true
+  rx_slot_mode: stereo
+  rx_mic_slots: [left, right]
+  aec_reference: ring_buffer
+  buffers_in_psram: true
+  i2s_lrclk_pin: GPIO7
+  i2s_bclk_pin: GPIO6
+  i2s_din_pin: GPIO4
+  i2s_dout_pin: GPIO8
+
+microphone:
+  - platform: esp_audio_stack
+    id: stack_mic
+    esp_audio_stack_id: audio_stack
+
+speaker:
+  - platform: esp_audio_stack
+    id: stack_speaker
+    esp_audio_stack_id: audio_stack

--- a/tests/test_audio_stack_cpp_contract.py
+++ b/tests/test_audio_stack_cpp_contract.py
@@ -175,3 +175,69 @@ def test_failed_tx_write_cannot_leave_stale_completion_metadata() -> None:
     assert dma_write.count("mark_tx_completion_desync_") == 2
     assert "if (!this->write_tx_frame_(ctx, tx_data, tx_bytes))" in dma_write
     assert "if (!this->write_tx_frame_(ctx, bytes + offset" in dma_write
+
+
+def _dual_mic_slots_ok(
+    processor_mic_channels: int,
+    use_tdm_bus: bool,
+    tdm_second_mic_slot: int,
+    rx_slot_mode_stereo: bool,
+    std_second_mic_slot: int,
+) -> bool:
+    """Mirror audio_session_ dual-mic slot gating (must stay in lockstep with C++)."""
+    if processor_mic_channels <= 1:
+        return True
+    have_tdm_dual_mic = use_tdm_bus and tdm_second_mic_slot >= 0
+    have_std_dual_mic = rx_slot_mode_stereo and std_second_mic_slot >= 0
+    return have_tdm_dual_mic or have_std_dual_mic
+
+
+def test_std_stereo_dual_mic_does_not_require_tdm() -> None:
+    cpp = read("audio_pipeline.cpp")
+    header = read("esp_audio_stack.h")
+    init = (AUDIO_STACK / "__init__.py").read_text(encoding="utf-8")
+
+    assert "dual-mic processor requires TDM microphone slots or STD rx_mic_slots" in cpp
+    assert 'alloc_fail("dual-mic processor requires TDM microphone slots")' not in cpp
+    assert "have_std_dual_mic = ctx.rx_slot_mode_stereo && ctx.std_second_mic_slot >= 0" in cpp
+    assert "have_tdm_dual_mic = ctx.use_tdm_bus && ctx.tdm_second_mic_slot >= 0" in cpp
+
+    stereo = cpp[
+        cpp.index("bool ESPAudioStack::process_rx_stereo_slot_(") : cpp.index(
+            "bool ESPAudioStack::process_rx_mono_effects_("
+        )
+    ]
+    assert "SPH0645" in stereo
+    assert "dc_primary_" in stereo
+    assert "dc_secondary_" in stereo
+    assert "L-R canceller" in stereo
+    assert "ctx.processor_input = ctx.processor_mic_buffer" in stereo
+    assert "process_multi_32" in stereo
+    assert "num_mic_ch" not in stereo or ", 2)" in stereo
+    assert "const uint8_t mic_offset = this->mic_channel_right_ ? 1 : 0;" in stereo
+    assert "uint8_t ch_offsets[1] = {mic_offset};" in stereo
+    assert "uint8_t ch_offsets[2] = {ctx.std_primary_mic_slot, static_cast<uint8_t>(ctx.std_second_mic_slot)};" in stereo
+
+    dc = cpp[
+        cpp.index("void ESPAudioStack::apply_input_conditioning_(") : cpp.index(
+            "void ESPAudioStack::update_tdm_slot_levels_"
+        )
+    ]
+    assert "dc_primary_.process" in dc
+    assert "dc_secondary_.process" in dc
+    assert "L-R canceller" in dc
+
+    assert "void set_std_mic_slots" in header
+    assert "std_second_mic_slot_{-1}" in header
+    assert "CONF_RX_MIC_SLOTS = \"rx_mic_slots\"" in init
+    assert "rx_mic_slots requires rx_slot_mode: stereo" in init
+    assert "use_stereo_aec_reference is" in init
+
+    # Single-mic stereo-slot still allocates; dual-mic STD does not trip the
+    # old TDM-only fail; TDM dual-mic still requires two TDM slots.
+    assert _dual_mic_slots_ok(1, False, -1, True, -1)
+    assert _dual_mic_slots_ok(2, False, -1, True, 1)
+    assert not _dual_mic_slots_ok(2, False, -1, True, -1)
+    assert not _dual_mic_slots_ok(2, False, -1, False, 1)
+    assert _dual_mic_slots_ok(2, True, 2, False, -1)
+    assert not _dual_mic_slots_ok(2, True, -1, False, -1)

--- a/tests/test_upstream_readiness_contract.py
+++ b/tests/test_upstream_readiness_contract.py
@@ -174,3 +174,12 @@ def test_upstream_yaml_tests_cover_maintained_targets() -> None:
     gmf_text = read(ROOT / "tests" / "components" / "esp_afe" / "test.esp32-p4-gmf-idf.yaml")
     assert "mic_num: 2" in gmf_text
     assert "se_enabled: true" in gmf_text
+
+    std_dual = read(
+        ROOT / "tests" / "components" / "esp_audio_stack" / "test.esp32-s3-std-dual-mic-idf.yaml"
+    )
+    assert "rx_slot_mode: stereo" in std_dual
+    assert "rx_mic_slots: [left, right]" in std_dual
+    assert "mic_num: 2" in std_dual
+    assert "se_enabled: true" in std_dual
+    assert "use_stereo_aec_reference" not in std_dual


### PR DESCRIPTION
## Summary
- Codec-less dual MEMS on one Philips I2S data line (two SPH0645/INMP441, SEL L/R, shared BCLK/LRCLK, no codec) cannot use TDM. Session setup previously failed with `dual-mic processor requires TDM microphone slots`.
- `rx_slot_mode: stereo` plus `rx_mic_slots: [left, right]` deinterleaves both STD slots, runs per-channel DC (`dc_primary_` / `dc_secondary_`), and feeds the existing interleaved `processor_mic_buffer` layout so `esp_afe` `mic_num: 2` does not need a second protocol.
- Default is unchanged: `rx_slot_mode: stereo` + `mic_channel: left|right` is still one mic. Do not set `use_stereo_aec_reference` for a second MEMS (that flag is ES8311 DAC feedback). `esp_aec` stays mono-reference.
- The public `microphone:` platform stays 16-bit mono. This does **not** close #6 (independent L/R mic entities / per-slot `sound_level` for e.g. StackChan head steering).

Closes #5

Replaces draft #10, which was based on `main` / `v2026.7.0` so an Onju Voice pin would not pick up current `dev` I2S-lifecycle work. This branch is that dual-mic commit cherry-picked onto current `dev`. The `idle_teardown` and AEC rate-converter OOM fixes from #10 will come as separate PRs after they are rewritten against `dev`'s I2S completion isolation.

## Test plan
- [x] `pytest tests/test_audio_stack_cpp_contract.py tests/test_upstream_readiness_contract.py` (19 passed on this branch)
- [x] YAML example: `tests/components/esp_audio_stack/test.esp32-s3-std-dual-mic-idf.yaml`
- [x] Same dual-mic topology is running on Onju Voice (ESP32-S3, codec-less dual SPH0645, `esp_afe` `mic_num: 2`, `rx_mic_slots: [left, right]`) via the `main`-based pin `benklop/esphome-audio-stack@feat/std-i2s-stereo-dual-mic`
- [ ] Confirm TDM `tdm_mic_slots: [0, 2]` dual-mic path still works on a TDM board

I do not have a TDM board, so I cannot do this last test.