### PR TITLE
fix: keep I2S completion ISR out of flash (ESP32-P4 silent watchdog reset at OTA validation write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- The IRAM-safe I2S completion callback no longer calls `std::atomic` member
+  functions, which GCC could place in flash. With `CONFIG_I2S_ISR_IRAM_SAFE`
+  the callback runs during flash writes; on ESP32-P4 the resulting flash fetch
+  deadlocked the chip at the first flash write after boot (typically the OTA
+  validation write at 60 s), so the update was rolled back silently.
+
 ## 2026.9.0, 2026-08-29
 
 This release keeps the existing YAML contract compatible with the 2026.8.0

--- a/esphome/components/esp_audio_stack/esp_audio_stack.cpp
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.cpp
@@ -1189,9 +1189,29 @@ void ESPAudioStack::deinit_i2s_() {
   ESP_LOGI(TAG, "I2S deinitialized");
 }
 
+// This callback runs from the I2S/GDMA interrupt with CONFIG_I2S_ISR_IRAM_SAFE, i.e. it also runs
+// while the flash cache is suspended for a flash write (NVS commit, OTA validation). Nothing it
+// executes may live in flash. std::atomic<T> member functions are ordinary inline functions and at
+// -Os GCC is free to emit them out of line, into .flash.text; on the ESP32-P4 that fetch deadlocks
+// the core silently (watchdog reset, no panic output). Use the compiler builtins instead: they are
+// always expanded inline.
+static_assert(sizeof(std::atomic<bool>) == sizeof(bool) && std::atomic<bool>::is_always_lock_free,
+              "ISR helpers assume std::atomic<bool> is a plain lock-free bool");
+static_assert(sizeof(std::atomic<uint32_t>) == sizeof(uint32_t) && std::atomic<uint32_t>::is_always_lock_free,
+              "ISR helpers assume std::atomic<uint32_t> is a plain lock-free uint32_t");
+static inline bool IRAM_ATTR isr_load_flag(const std::atomic<bool> &flag) {
+  return __atomic_load_n(reinterpret_cast<const bool *>(&flag), __ATOMIC_ACQUIRE);
+}
+static inline uint32_t IRAM_ATTR isr_load_u32(const std::atomic<uint32_t> &value) {
+  return __atomic_load_n(reinterpret_cast<const uint32_t *>(&value), __ATOMIC_RELAXED);
+}
+static inline void IRAM_ATTR isr_increment_u32(std::atomic<uint32_t> &value) {
+  __atomic_fetch_add(reinterpret_cast<uint32_t *>(&value), 1U, __ATOMIC_RELAXED);
+}
+
 bool IRAM_ATTR ESPAudioStack::tx_on_sent_callback(i2s_chan_handle_t handle, i2s_event_data_t *event, void *user_ctx) {
   auto *self = static_cast<ESPAudioStack *>(user_ctx);
-  if (self == nullptr || !self->tx_completion_tracking_active_.load(std::memory_order_acquire) ||
+  if (self == nullptr || !isr_load_flag(self->tx_completion_tracking_active_) ||
       self->tx_completion_event_queue_ == nullptr) {
     return false;
   }
@@ -1214,10 +1234,10 @@ bool IRAM_ATTR ESPAudioStack::tx_on_sent_callback(i2s_chan_handle_t handle, i2s_
     // Once real speaker data is pending, losing a timestamp may lose its
     // completion boundary. Preserve the fail-closed behaviour in that case so
     // output callbacks (notably AEC reference tracking) cannot silently drift.
-    if (self->tx_completion_pending_real_records_.load(std::memory_order_relaxed) > 0) {
+    if (isr_load_u32(self->tx_completion_pending_real_records_) > 0) {
       self->tx_completion_desync_ = true;
     } else {
-      self->tx_completion_idle_event_drops_.fetch_add(1, std::memory_order_relaxed);
+      isr_increment_u32(self->tx_completion_idle_event_drops_);
     }
   }
   xQueueSendToBackFromISR(self->tx_completion_event_queue_, &now, &need_yield2);

--- a/tests/test_audio_stack_cpp_contract.py
+++ b/tests/test_audio_stack_cpp_contract.py
@@ -66,9 +66,9 @@ def test_idle_tx_completion_overflow_preserves_full_duplex_capture() -> None:
     ]
 
     assert "tx_completion_idle_event_drops_" in header
-    assert "tx_completion_pending_real_records_.load" in callback
+    assert "isr_load_u32(self->tx_completion_pending_real_records_)" in callback
     assert "self->tx_completion_desync_ = true" in callback
-    assert "self->tx_completion_idle_event_drops_.fetch_add" in callback
+    assert "isr_increment_u32(self->tx_completion_idle_event_drops_)" in callback
     assert "Discarded %u idle TX completion events" in cpp
 
 
@@ -84,7 +84,7 @@ def test_tx_completion_tracking_is_session_scoped() -> None:
     enable = cpp[cpp.index("bool ESPAudioStack::enable_i2s_channels_()") : cpp.index("void ESPAudioStack::close_audio_io_")]
 
     assert "std::atomic<bool> tx_completion_tracking_active_{false}" in header
-    assert "tx_completion_tracking_active_.load(std::memory_order_acquire)" in callback
+    assert "isr_load_flag(self->tx_completion_tracking_active_)" in callback
     assert stop.index("tx_completion_tracking_active_.store(false") < stop.index(
         "audio_stack_running_.store(false"
     )
@@ -101,6 +101,32 @@ def test_tx_completion_tracking_is_session_scoped() -> None:
     assert "has_i2s_error_.store(true" in failure
     assert "audio_stack_running_.store(false" in failure
     assert "teardown_pending_.store(true" in failure
+
+
+def test_tx_completion_isr_never_calls_into_flash() -> None:
+    """The IRAM-safe I2S callback runs while the flash cache is suspended.
+
+    std::atomic<T> member functions are ordinary inline functions; at -Os GCC may
+    emit them out of line in .flash.text, and an IRAM ISR calling into flash during
+    a flash write deadlocks the ESP32-P4 silently (watchdog reset, no panic). The
+    callback must therefore use the compiler builtins, which always expand inline.
+    """
+    cpp = read("esp_audio_stack.cpp")
+    helpers = cpp[
+        cpp.index("static inline bool IRAM_ATTR isr_load_flag(") :
+        cpp.index("bool IRAM_ATTR ESPAudioStack::tx_on_sent_callback")
+    ]
+    callback = cpp[
+        cpp.index("bool IRAM_ATTR ESPAudioStack::tx_on_sent_callback") :
+        cpp.index("bool ESPAudioStack::prepare_tx_completion_tracking_")
+    ]
+
+    assert "__atomic_load_n(" in helpers
+    assert "__ATOMIC_ACQUIRE" in helpers
+    assert "__atomic_fetch_add(" in helpers
+    assert "static_assert(sizeof(std::atomic<bool>) == sizeof(bool)" in cpp
+    for forbidden in (".load(", ".store(", ".fetch_add(", ".exchange(", "std::memory_order"):
+        assert forbidden not in callback, forbidden
 
 
 def test_children_can_restart_after_parent_i2s_recovery() -> None:


### PR DESCRIPTION
## Summary

v2026.9.0 hangs an ESP32-P4 at the first flash write after boot — normally ESPHome's OTA-validation write at `boot_is_good_after` (60 s) — with a silent `rst:0x7 (HP_SYS_HP_WDT_RESET)` and no panic output, so the bootloader rolls the update back while `esphome run` reports success. v2026.7.0 is stable on the same board.

**Root cause:** `07041f5` added `tx_completion_tracking_active_.load(std::memory_order_acquire)` to the `IRAM_ATTR` `tx_on_sent_callback`. With ESPHome's `-Os`, GCC emits that as an out-of-line `std::atomic<bool>::load(std::memory_order) const` in `.flash.text`, and the ISR `jalr`s into it:

```
4ff01198 <esphome::esp_audio_stack::ESPAudioStack::tx_on_sent_callback(...)>:
4ff011ba:  jalr  -1684(ra)   # 4002db22 <std::atomic<bool>::load(std::memory_order) const>
4ff011c6:  jal   4ff00d60 <esp_timer_get_time>
4ff011d4:  jal   4ff08520 <xQueueIsQueueFullFromISR>
...
```

Because this component forces `CONFIG_I2S_ISR_IRAM_SAFE=y`, the callback keeps running while the flash cache is suspended for a flash write. On the ESP32-P4 a flash fetch that misses the cache in that state does not fault — it blocks the core's L1 cache and deadlocks the chip (see the comment in IDF's `mspi_timing_tuning.c`), which is why there is no panic. Whether that 18-byte function's line happens to be cache-resident at the instant of the write depends on the image layout and working set, which is why the failure is deterministic per build but shows up on some boards and not others. IDF's `i2s_channel_register_event_callback()` only checks that the callback pointer itself is in IRAM.

The v2026.7.0 ISR has no flash callee (verified by disassembly).

## Fix

Read the three ISR-side atomics through the compiler builtins (`__atomic_load_n`, `__atomic_fetch_add`), which are always expanded inline. Memory orders are unchanged (acquire on the flag, relaxed on the counters). Two `static_assert`s pin the layout assumption, and the comment above the helpers documents the constraint for future edits. The contract tests are updated accordingly, and a new test forbids `std::atomic` member calls / `std::memory_order` inside the callback.

## Verification (hardware)

ESP32-P4 rev1.3 (`esp32-p4-evboard`, 32 MB PSRAM @ 200 MHz), ESPHome 2026.8.2, ESP-IDF 5.5.5, ES8311 duplex with `esp_aec`, mic capture running from boot. Each run is an OTA followed by the 60 s validation write and an NVS write a few seconds later; PASS/FAIL from the API log and the USB-Serial-JTAG reset banner.

| Build | Result |
|-------|--------|
| v2026.9.0 as released | FAIL (5/5, incl. an earlier 3/3), dies on the `Boot seems successful` line |
| v2026.9.0, `safe_mode.boot_is_good_after: 3min` | FAIL — hang moves to 184 s, same line |
| v2026.9.0 + IDF-master backport of the parked-core branch-predictor fix (espressif/esp-idf#18948) | FAIL ×2 — unrelated |
| v2026.9.0 with `CONFIG_I2S_ISR_IRAM_SAFE` not forced (ISR masked during flash ops) | PASS |
| v2026.9.0 + only the flag load changed to `__atomic_load_n` | PASS (ELF: all ISR callees in IRAM, `fence r,rw` inline) |
| **this PR, stock IDF 5.5.5** | **PASS** — survives the validation write and NVS writes |

Local `ruff check esphome tests` and `pytest -q` pass (29 tests).

## Notes

- The IDF-side constraint is general: nothing reachable from this callback may live in flash. A cheap CI guard would be to objdump `tx_on_sent_callback` after a build and fail on any `jal`/`jalr` target outside IRAM; I did not add that here because the contract tests are source-level only.
- Full investigation write-up with logs is available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
