### PR TITLE
Reduce DMA use for sparse TDM slot layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Development
+
+- TDM RX and TX now transfer only their configured active slots through DMA
+  while retaining the complete physical slot count for BCLK/WS timing. This
+  reduces internal DMA memory on sparse layouts such as dual microphones plus
+  an echo-reference input and a single playback slot.
+- The new `processor_dma_margin` option can disable the automatic 25% TDM
+  processor-frame headroom on memory-constrained targets. It defaults to
+  enabled, preserving existing configurations.
+
+---
+
 ## ESPHome Audio Stack 2026.9.2
 
 More reliable audio startup and firmware updates, with optional dual-microphone features.

--- a/docs/esp_audio_stack.rst
+++ b/docs/esp_audio_stack.rst
@@ -119,9 +119,13 @@ I2S bus (single-bus mode):
   ``512``. Defaults to ``256``.
 - **use_apll** (*Optional*, boolean): Use the APLL clock source. Among the
   supported targets, this is available on ESP32-P4. Defaults to ``false``.
-- **dma_desc_num** (*Optional*, int): DMA descriptor count, ``2`` to ``16``. Defaults to ``6``.
+- **dma_desc_num** (*Optional*, int): Initial DMA descriptor count, ``2`` to ``16``. Defaults to
+  ``6``. A TDM processor may raise the effective count to cover its processor-frame target.
 - **dma_frame_num** (*Optional*, int): Frames per DMA descriptor, ``64`` to ``4092``. When omitted, the
   component sizes descriptors at approximately 10 ms each.
+- **processor_dma_margin** (*Optional*, boolean): Add 25% DMA headroom above one complete TDM
+  processor frame. Defaults to ``true``. If disabled, the queue still expands to at least one
+  complete frame.
 
 Dual-bus mode (separate microphone and speaker peripherals):
 
@@ -157,6 +161,9 @@ Processor and echo-cancellation reference:
   Must not contain duplicates or the reference slot.
 - **tdm_ref_slot** (*Optional*, int): Slot carrying the speaker reference, ``0`` to ``7``. Defaults to ``1``.
 - **tdm_tx_slot** (*Optional*, int): Playback slot, ``0`` to ``7``. Defaults to ``0``.
+
+The physical TDM frame retains ``tdm_total_slots`` for BCLK/WS timing. RX DMA transfers only the
+configured microphone/reference slots, while TX DMA transfers only ``tdm_tx_slot``.
 
 Hardware codec (``codec:`` block):
 

--- a/docs/esphome.io/components/esp_audio_stack.mdx
+++ b/docs/esphome.io/components/esp_audio_stack.mdx
@@ -80,8 +80,9 @@ board requires values different from the defaults.
 - **i2s_comm_fmt** (*Optional*, string): Frame format. One of `philips`, `msb`, `pcm_short`, `pcm_long`. Defaults to `philips`.
 - **mclk_multiple** (*Optional*, int): MCLK to sample-rate ratio. One of `128`, `256`, `384`, `512`. Defaults to `256`.
 - **use_apll** (*Optional*, boolean): Use the APLL clock source. In the maintained target set, only ESP32-P4 supports it. Defaults to `false`.
-- **dma_desc_num** (*Optional*, int): DMA descriptor count, from `2` to `16`. Defaults to `6`.
+- **dma_desc_num** (*Optional*, int): Initial DMA descriptor count, from `2` to `16`. Defaults to `6`. A TDM processor may raise the effective count to cover its processor-frame target.
 - **dma_frame_num** (*Optional*, int): Frames per DMA descriptor, from `64` to `4092`.
+- **processor_dma_margin** (*Optional*, boolean): Add 25% DMA headroom above one complete TDM processor frame. Defaults to `true`. If disabled, the queue still expands to at least one complete frame.
 
 ### Dual-bus I2S
 
@@ -104,6 +105,10 @@ Dual-bus mode does not support TDM.
 - **tdm_mic_slots** (*Optional*, list): One or two microphone slots for multi-microphone layouts.
 - **tdm_ref_slot** (*Optional*, int): Slot carrying the speaker reference, from `0` to `7`. Defaults to `1`.
 - **tdm_tx_slot** (*Optional*, int): Playback slot, from `0` to `7`. Defaults to `0`.
+
+The physical TDM frame always retains `tdm_total_slots` for its BCLK/WS timing.
+Only the configured microphone/reference slots are transferred through RX DMA,
+and only `tdm_tx_slot` is transferred through TX DMA.
 
 ### Codec
 

--- a/esphome/components/esp_audio_stack/README.md
+++ b/esphome/components/esp_audio_stack/README.md
@@ -403,8 +403,9 @@ First-version limits:
 | `task_priority` | int | 19 | FreeRTOS priority of the audio task (1-24). Default 19 is above lwIP (18), below WiFi (23). |
 | `task_core` | int | 0 | Core affinity: 0 or 1 for pinned, -1 for unpinned. Default 0 keeps the non-network realtime I2S bridge below Wi-Fi and above lwIP on the ESP-IDF protocol core. |
 | `task_stack_size` | int | 8192 | Audio task stack size in bytes (4096-32768). Increase if you see stack overflow warnings. |
-| `dma_desc_num` | int | 6 | I2S DMA descriptor count (2-16). Tune only from measured latency/underrun evidence. |
+| `dma_desc_num` | int | 6 | Initial I2S DMA descriptor count (2-16). TDM processor configurations may raise it automatically to cover the required processor-frame target. Tune only from measured memory/latency/underrun evidence. |
 | `dma_frame_num` | int | auto | Frames per DMA descriptor (64-4092). Omitted means a rate/layout-derived value near 10 ms, clamped to IDF limits. |
+| `processor_dma_margin` | bool | true | Add 25% DMA headroom above one complete TDM processor frame. Disable only on measured memory-constrained configurations; the queue still expands to at least one complete frame. |
 | `buffers_in_psram` | bool | false | Move component-owned frame buffers (RX scratch, speaker frame scratch, processor interleave, mic/ref/output buffers) to PSRAM where possible. DMA descriptors and I2S driver buffers remain internal. Saves internal heap on full builds at the cost of PSRAM traffic. |
 | `audio_task_stack_in_psram` | bool | false | Place the audio task's configured stack in PSRAM through ESPHome's PSRAM task-stack helper. This recovers approximately `task_stack_size` bytes of internal allocation at the cost of slower accesses. Enable only after measuring internal pressure and per-frame worst case. Requires `psram`; keep `false` when the target already has headroom. |
 | `aec_reference` | string | `ring_buffer` | Mono-mode AEC reference source for no-codec setups. `ring_buffer` is the Espressif/ADF TYPE2-style software reference: speaker TX is staged in a delay-tunable ring before being fed to the processor. `previous_frame` is a lighter custom mode that reuses the prior TX frame, with no ring buffer and no delay tuning. Ignored when `use_stereo_aec_reference` or `use_tdm_reference` is true. |
@@ -855,8 +856,13 @@ esp_audio_stack:
 - **DMA Buffers**: owned by Espressif's official `esp_driver_i2s` channel layer.
   YAML exposes `dma_desc_num` (default 6) and optional `dma_frame_num`. When
   `dma_frame_num` is omitted, the component derives roughly 10 ms descriptors
-  and clamps them to IDF limits. Change either value only from measured
-  underrun/latency evidence, then retest every active bus topology.
+  and clamps them to IDF limits. TDM transfers retain `tdm_total_slots` as the
+  physical BCLK/WS frame but move only the configured RX and TX slots through
+  their respective DMA paths. For a TDM processor, `dma_desc_num` is raised as
+  needed for one processor frame plus 25% headroom. Set
+  `processor_dma_margin: false` to omit only that extra margin; the queue still
+  expands to one full processor frame. Change these values only from measured
+  memory, underrun and latency evidence, then retest every active bus topology.
 - **Speaker Buffer**: the public `speaker: platform: esp_audio_stack` exposes ESPHome-compatible `buffer_duration` and `timeout` options. Default `buffer_duration: 500ms` allocates a mono PCM staging ring at the I2S bus rate, preferably in PSRAM. `timeout` defaults to `never`; set an explicit value such as `10s` only when the hardware speaker should auto-stop after an abandoned writer.
 - **Task Priority**: 19 (above lwIP at 18, below WiFi at 23). Configurable via `task_priority` YAML option.
 - **Core Affinity**: Pinned to Core 0 by default for the non-network realtime

--- a/esphome/components/esp_audio_stack/__init__.py
+++ b/esphome/components/esp_audio_stack/__init__.py
@@ -76,6 +76,7 @@ CONF_TASK_CORE = "task_core"
 CONF_TASK_STACK_SIZE = "task_stack_size"
 CONF_DMA_DESC_NUM = "dma_desc_num"
 CONF_DMA_FRAME_NUM = "dma_frame_num"
+CONF_PROCESSOR_DMA_MARGIN = "processor_dma_margin"
 CONF_TX_CHANNEL = "tx_channel"
 CONF_SPEAKER_CHANNELS = "speaker_channels"
 CONF_BUFFERS_IN_PSRAM = "buffers_in_psram"
@@ -487,6 +488,7 @@ CONFIG_SCHEMA = cv.All(
             # the component keeps the historical ~10 ms/descriptor auto sizing.
             cv.Optional(CONF_DMA_DESC_NUM, default=6): cv.int_range(min=2, max=16),
             cv.Optional(CONF_DMA_FRAME_NUM): cv.int_range(min=64, max=4092),
+            cv.Optional(CONF_PROCESSOR_DMA_MARGIN, default=True): cv.boolean,
             # Use PSRAM for non-DMA audio buffers (saves ~15KB internal RAM).
             # Requires PSRAM. DMA buffers (I2S RX/TX) always use internal RAM.
             cv.Optional(CONF_BUFFERS_IN_PSRAM, default=False): cv.boolean,
@@ -885,6 +887,7 @@ async def to_code(config):
             (CONF_TASK_CORE, var.set_task_core),
             (CONF_TASK_STACK_SIZE, var.set_task_stack_size),
             (CONF_DMA_DESC_NUM, var.set_dma_desc_num),
+            (CONF_PROCESSOR_DMA_MARGIN, var.set_processor_dma_margin),
             (CONF_BUFFERS_IN_PSRAM, var.set_buffers_in_psram),
             (CONF_AUDIO_TASK_STACK_IN_PSRAM, var.set_audio_task_stack_in_psram),
         ),

--- a/esphome/components/esp_audio_stack/audio_pipeline.cpp
+++ b/esphome/components/esp_audio_stack/audio_pipeline.cpp
@@ -172,7 +172,7 @@ bool ESPAudioStack::allocate_audio_buffers_(AudioTaskCtx &ctx) {
   size_t tdm_tx_bytes = 0;
   size_t tx_silence_bytes = 0;
 #ifdef USE_ESP_AUDIO_STACK_TDM_BUS
-  tdm_tx_bytes = ctx.use_tdm_bus ? ctx.bus_frame_size * ctx.tdm_total_slots * ctx.i2s_bps : 0;
+  tdm_tx_bytes = ctx.use_tdm_bus ? ctx.bus_frame_size * ctx.tdm_tx_active_slots * ctx.i2s_bps : 0;
   tx_silence_bytes = ctx.use_tdm_bus ? ctx.bus_frame_bytes : 0;
 #endif
   size_t tx_interleave_bytes = 0;
@@ -193,7 +193,7 @@ bool ESPAudioStack::allocate_audio_buffers_(AudioTaskCtx &ctx) {
 #ifdef USE_ESP_AUDIO_STACK_MULTI_RX
     if (ctx.use_tdm_bus || ctx.use_stereo_aec_ref || ctx.rx_slot_mode_stereo) {
       ready = this->rx_rate_converter_.prepare(ctx.bus_frame_size, ctx.input_frame_size, ctx.rx_rate_converter_channels,
-                                               ctx.use_tdm_bus ? ctx.tdm_total_slots : 2, ctx.i2s_bps == 4);
+                                               ctx.use_tdm_bus ? ctx.tdm_rx_active_slots : 2, ctx.i2s_bps == 4);
       rx_prepared = true;
     }
 #endif
@@ -256,7 +256,7 @@ bool ESPAudioStack::allocate_audio_buffers_(AudioTaskCtx &ctx) {
     }
 #ifdef USE_ESP_AUDIO_STACK_32BIT
     if (ready && tx_32_bytes > 0) {
-      const uint8_t tx_channels = ctx.use_tdm_bus ? ctx.tdm_total_slots : ctx.num_ch;
+      const uint8_t tx_channels = ctx.use_tdm_bus ? ctx.tdm_tx_active_slots : ctx.num_ch;
       if (this->tx_bit_cvt_handle_ != nullptr && this->tx_bit_cvt_channels_ != tx_channels) {
         esp_ae_bit_cvt_close(static_cast<esp_ae_bit_cvt_handle_t>(this->tx_bit_cvt_handle_));
         this->tx_bit_cvt_handle_ = nullptr;
@@ -566,6 +566,18 @@ bool ESPAudioStack::prepare_audio_context_(AudioTaskCtx &ctx, bool require_proce
   ctx.ref_channel_right = this->ref_channel_right_;
   ctx.correct_dc_offset = this->correct_dc_offset_;
   ctx.tdm_total_slots = this->tdm_total_slots_;
+  if (ctx.use_tdm_bus) {
+    const uint16_t rx_mask = this->tdm_rx_slot_mask_();
+    const uint16_t tx_mask = this->tdm_tx_slot_mask_();
+    ctx.tdm_rx_active_slots = this->tdm_active_slot_count_(rx_mask);
+    ctx.tdm_tx_active_slots = this->tdm_active_slot_count_(tx_mask);
+    ctx.tdm_mic_dma_slot = this->tdm_packed_slot_index_(rx_mask, this->tdm_mic_slot_);
+    ctx.tdm_second_mic_dma_slot = this->tdm_second_mic_slot_ >= 0
+                                       ? this->tdm_packed_slot_index_(rx_mask, this->tdm_second_mic_slot_)
+                                       : -1;
+    ctx.tdm_ref_dma_slot = this->tdm_packed_slot_index_(rx_mask, this->tdm_ref_slot_);
+    ctx.tdm_tx_dma_slot = this->tdm_packed_slot_index_(tx_mask, this->tdm_tx_slot_);
+  }
   ctx.tdm_mic_slot = this->tdm_mic_slot_;
   ctx.tdm_second_mic_slot = this->tdm_second_mic_slot_;
   ctx.tdm_ref_slot = this->tdm_ref_slot_;
@@ -632,7 +644,7 @@ bool ESPAudioStack::prepare_audio_context_(AudioTaskCtx &ctx, bool require_proce
   ctx.bus_frame_bytes = ctx.bus_frame_size * sizeof(int16_t);
   ctx.speaker_frame_bytes = ctx.bus_frame_bytes * ctx.speaker_channels;
   if (ctx.use_tdm_bus) {
-    ctx.rx_frame_bytes = ctx.bus_frame_size * ctx.tdm_total_slots * ctx.i2s_bps;
+    ctx.rx_frame_bytes = ctx.bus_frame_size * ctx.tdm_rx_active_slots * ctx.i2s_bps;
   } else if (ctx.use_stereo_aec_ref || ctx.rx_slot_mode_stereo) {
     ctx.rx_frame_bytes = ctx.bus_frame_size * 2 * ctx.i2s_bps;
   } else {
@@ -768,7 +780,7 @@ void ESPAudioStack::audio_session_() {
   ctx.tx_clock_buffer = this->prealloc_tx_clock_buffer_;
 #ifdef USE_ESP_AUDIO_STACK_TDM_BUS
   if (ctx.use_tdm_bus) {
-    ctx.tdm_tx_frame_bytes = ctx.bus_frame_size * ctx.tdm_total_slots * ctx.i2s_bps;
+    ctx.tdm_tx_frame_bytes = ctx.bus_frame_size * ctx.tdm_tx_active_slots * ctx.i2s_bps;
   }
 #endif
 
@@ -1063,19 +1075,19 @@ bool ESPAudioStack::process_rx_passthrough_(AudioTaskCtx &ctx) {
 
 #if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
 bool ESPAudioStack::process_rx_tdm_(AudioTaskCtx &ctx) {
-  const uint8_t ts = ctx.tdm_total_slots;
+  const uint8_t ts = ctx.tdm_rx_active_slots;
   const bool dual_mic = ctx.processor_mic_channels > 1 && ctx.tdm_second_mic_slot >= 0;
   uint8_t ch_offsets[MAX_RATE_CVT_CHANNELS];
   uint8_t num_mic_ch = dual_mic ? 2 : 1;
   uint8_t selected_channels = 0;
   if (dual_mic) {
-    ch_offsets[selected_channels++] = ctx.tdm_mic_slot;
-    ch_offsets[selected_channels++] = static_cast<uint8_t>(ctx.tdm_second_mic_slot);
+    ch_offsets[selected_channels++] = ctx.tdm_mic_dma_slot;
+    ch_offsets[selected_channels++] = static_cast<uint8_t>(ctx.tdm_second_mic_dma_slot);
   } else {
-    ch_offsets[selected_channels++] = ctx.tdm_mic_slot;
+    ch_offsets[selected_channels++] = ctx.tdm_mic_dma_slot;
   }
   if (ctx.use_tdm_ref) {
-    ch_offsets[selected_channels++] = ctx.tdm_ref_slot;
+    ch_offsets[selected_channels++] = ctx.tdm_ref_dma_slot;
   }
   if (selected_channels != ctx.rx_rate_converter_channels) {
     this->fail_audio_session_("TDM RX channel map");
@@ -1296,17 +1308,23 @@ void ESPAudioStack::update_tdm_slot_levels_(const AudioTaskCtx &ctx) {
   this->tdm_slot_level_divider_ = 0;
 
   const size_t frame_samples = ctx.bus_frame_size;
-  const size_t slot_stride = slot_limit;
+  const uint16_t rx_mask = ctx.use_tdm_bus ? this->tdm_rx_slot_mask_() : 0x3;
+  const size_t slot_stride = ctx.use_tdm_bus ? ctx.tdm_rx_active_slots : slot_limit;
   for (size_t i = 0; i < enabled_count; i++) {
-    uint8_t slot = enabled_slots[i];
+    const uint8_t slot = enabled_slots[i];
+    if ((rx_mask & (1U << slot)) == 0) {
+      this->tdm_slot_level_dbfs_[slot].store(-120.0f, std::memory_order_relaxed);
+      continue;
+    }
+    const uint8_t dma_slot = ctx.use_tdm_bus ? this->tdm_packed_slot_index_(rx_mask, slot) : slot;
     float dbfs;
     if (ctx.i2s_bps == 4) {
       // 32-bit mode: rx_buffer stays native; esp_audio_effects handles bit
       // conversion later.
       auto *src32 = reinterpret_cast<const int32_t *>(ctx.rx_buffer);
-      dbfs = compute_rms_dbfs_i32_top16(src32 + slot, frame_samples, slot_stride);
+      dbfs = compute_rms_dbfs_i32_top16(src32 + dma_slot, frame_samples, slot_stride);
     } else {
-      dbfs = compute_rms_dbfs_i16(ctx.rx_buffer + slot, frame_samples, slot_stride);
+      dbfs = compute_rms_dbfs_i16(ctx.rx_buffer + dma_slot, frame_samples, slot_stride);
     }
     this->tdm_slot_level_dbfs_[slot].store(dbfs, std::memory_order_relaxed);
   }
@@ -1364,12 +1382,19 @@ void ESPAudioStack::process_aec_and_callbacks_(AudioTaskCtx &ctx) {
         auto log_tdm_ref_monitor = [&](const char *label, uint32_t silent_frames) {
           float raw_slot_dbfs[4] = {-120.0f, -120.0f, -120.0f, -120.0f};
           const uint8_t raw_slot_count = std::min<uint8_t>(ctx.tdm_total_slots, 4);
+          const uint16_t rx_mask = this->tdm_rx_slot_mask_();
           for (uint8_t slot = 0; slot < raw_slot_count; slot++) {
+            if ((rx_mask & (1U << slot)) == 0) {
+              continue;
+            }
+            const uint8_t dma_slot = this->tdm_packed_slot_index_(rx_mask, slot);
             if (ctx.i2s_bps == 4) {
               auto *src32 = reinterpret_cast<const int32_t *>(ctx.rx_buffer);
-              raw_slot_dbfs[slot] = compute_rms_dbfs_i32_top16(src32 + slot, ctx.bus_frame_size, ctx.tdm_total_slots);
+              raw_slot_dbfs[slot] =
+                  compute_rms_dbfs_i32_top16(src32 + dma_slot, ctx.bus_frame_size, ctx.tdm_rx_active_slots);
             } else {
-              raw_slot_dbfs[slot] = compute_rms_dbfs_i16(ctx.rx_buffer + slot, ctx.bus_frame_size, ctx.tdm_total_slots);
+              raw_slot_dbfs[slot] =
+                  compute_rms_dbfs_i16(ctx.rx_buffer + dma_slot, ctx.bus_frame_size, ctx.tdm_rx_active_slots);
             }
           }
           ESP_LOGW(TAG,
@@ -1538,7 +1563,7 @@ bool ESPAudioStack::tx_bit_cvt_16_to_32_(uint8_t channels, const void *in, uint3
 #endif
 
 bool ESPAudioStack::format_tx_frame_(AudioTaskCtx &ctx, void **tx_data, size_t *tx_bytes) {
-  const uint8_t tx_channels = ctx.use_tdm_bus ? ctx.tdm_total_slots : ctx.num_ch;
+  const uint8_t tx_channels = ctx.use_tdm_bus ? ctx.tdm_tx_active_slots : ctx.num_ch;
   int16_t *formatted16 = ctx.spk_buffer;
   bool tx_formatted = false;
 
@@ -1552,11 +1577,12 @@ bool ESPAudioStack::format_tx_frame_(AudioTaskCtx &ctx, void **tx_data, size_t *
     for (uint8_t slot = 0; slot < tx_channels; slot++) {
       slot_samples[slot] = ctx.tx_silence_buffer;
     }
-    if (ctx.tdm_tx_slot >= tx_channels) {
-      ESP_LOGE(TAG, "tdm_tx_slot %u out of range for %u slots", (unsigned) ctx.tdm_tx_slot, (unsigned) tx_channels);
+    if (ctx.tdm_tx_dma_slot >= tx_channels) {
+      ESP_LOGE(TAG, "packed tdm_tx_slot %u out of range for %u active slots", (unsigned) ctx.tdm_tx_dma_slot,
+               (unsigned) tx_channels);
       return false;
     }
-    slot_samples[ctx.tdm_tx_slot] = ctx.spk_buffer;
+    slot_samples[ctx.tdm_tx_dma_slot] = ctx.spk_buffer;
     const esp_ae_err_t err = esp_ae_intlv_process(tx_channels, 16, static_cast<uint32_t>(ctx.bus_frame_size),
                                                   slot_samples, ctx.tdm_tx_buffer);
     if (err != ESP_AE_ERR_OK) {

--- a/esphome/components/esp_audio_stack/esp_audio_stack.cpp
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.cpp
@@ -329,6 +329,30 @@ static i2s_tdm_slot_config_t get_tdm_slot_config(uint8_t fmt, i2s_data_bit_width
 }
 #endif  // SOC_I2S_SUPPORTS_TDM
 
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+uint16_t ESPAudioStack::tdm_rx_slot_mask_() const {
+  uint16_t mask = static_cast<uint16_t>(1U << this->tdm_mic_slot_);
+  if (this->tdm_second_mic_slot_ >= 0) {
+    mask |= static_cast<uint16_t>(1U << this->tdm_second_mic_slot_);
+  }
+  if (this->use_tdm_ref_) {
+    mask |= static_cast<uint16_t>(1U << this->tdm_ref_slot_);
+  }
+  return mask;
+}
+
+uint16_t ESPAudioStack::tdm_tx_slot_mask_() const { return static_cast<uint16_t>(1U << this->tdm_tx_slot_); }
+
+uint8_t ESPAudioStack::tdm_active_slot_count_(uint16_t mask) {
+  return static_cast<uint8_t>(__builtin_popcount(static_cast<unsigned>(mask)));
+}
+
+uint8_t ESPAudioStack::tdm_packed_slot_index_(uint16_t mask, uint8_t physical_slot) {
+  const uint16_t lower_slots = physical_slot == 0 ? 0 : static_cast<uint16_t>(mask & ((1U << physical_slot) - 1U));
+  return tdm_active_slot_count_(lower_slots);
+}
+#endif
+
 void ESPAudioStack::setup() {
   ESP_LOGCONFIG(TAG, "Setting up ESP Audio Stack (ESP-IDF I2S + esp_codec_dev backend)...");
 
@@ -691,9 +715,8 @@ bool ESPAudioStack::prepare_i2s_channels_() {
   }
 #if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
   if (this->use_tdm_bus_) {
-    const uint32_t tdm_frame = this->tdm_total_slots_ * bytes_per_sample;
-    tx_bytes_per_frame = tdm_frame;
-    rx_bytes_per_frame = tdm_frame;
+    tx_bytes_per_frame = this->tdm_active_slot_count_(this->tdm_tx_slot_mask_()) * bytes_per_sample;
+    rx_bytes_per_frame = this->tdm_active_slot_count_(this->tdm_rx_slot_mask_()) * bytes_per_sample;
   }
 #endif
   const uint32_t max_bytes_per_frame = std::max(tx_bytes_per_frame, rx_bytes_per_frame);
@@ -747,12 +770,14 @@ bool ESPAudioStack::prepare_i2s_channels_() {
     if (processor_bus_frames > 0) {
       auto ceil_div_u32 = [](uint32_t num, uint32_t den) -> uint32_t { return den == 0 ? 0 : (num + den - 1) / den; };
       // The audio task reads/writes one processor frame per loop. Keep enough
-      // DMA headroom for that full TDM frame plus margin; otherwise a 1024-sample
-      // AFE quantum can underflow a short DMA queue even though the YAML compiles.
+      // DMA headroom for that full TDM frame and, unless explicitly disabled,
+      // an additional 25% margin.
       // Do not change dma_frame_num here: it has already been selected as a
       // divisor of the logical TX frame so playback completion records stay in
       // lockstep with the I2S DMA callbacks.
-      const uint32_t target_total_frames = ceil_div_u32(processor_bus_frames * 5U, 4U);
+      const uint32_t target_total_frames = this->processor_dma_margin_
+                                               ? ceil_div_u32(processor_bus_frames * 5U, 4U)
+                                               : processor_bus_frames;
       if (target_total_frames > dma_desc_num * dma_frame_num) {
         const uint32_t old_desc = dma_desc_num;
         dma_desc_num = std::max(dma_desc_num, ceil_div_u32(target_total_frames, dma_frame_num));
@@ -825,17 +850,13 @@ bool ESPAudioStack::prepare_i2s_channels_() {
 
 #if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
   if (this->use_tdm_bus_) {
-    // ── TDM MODE: ES7210 multi-slot RX + ES8311 slot-0 TX ──
-    // STEREO with 4 slots: DMA contains all 4 interleaved slots, BCLK/FS = 64.
-    // ESP-IDF MONO only puts slot 0 in DMA; STEREO gives all active slots.
-    // total_slot is derived from slot_mask (not slot_mode), so BCLK doesn't change.
-    // ES8311 reads/writes slot 0 as standard I2S (first 16 bits after LRCLK edge).
-    // DMA frame = tdm_total_slots × 2 bytes. At 4 slots, 256 frames = 2048 bytes/desc (< 4092 limit).
-    i2s_tdm_slot_mask_t tdm_mask = I2S_TDM_SLOT0;
-    for (int i = 1; i < this->tdm_total_slots_; i++)
-      tdm_mask = static_cast<i2s_tdm_slot_mask_t>(tdm_mask | (I2S_TDM_SLOT0 << i));
+    // Keep the complete physical TDM frame for BCLK/WS while moving only the
+    // slots consumed by each direction through DMA. ESP-IDF packs enabled
+    // slots in ascending physical-slot order.
+    const auto tx_tdm_mask = static_cast<i2s_tdm_slot_mask_t>(this->tdm_tx_slot_mask_());
+    const auto rx_tdm_mask = static_cast<i2s_tdm_slot_mask_t>(this->tdm_rx_slot_mask_());
 
-    i2s_tdm_config_t tdm_cfg = {
+    i2s_tdm_config_t base_tdm_cfg = {
         .clk_cfg =
             {
                 .sample_rate_hz = this->sample_rate_,
@@ -843,7 +864,7 @@ bool ESPAudioStack::prepare_i2s_channels_() {
                 .ext_clk_freq_hz = 0,
                 .mclk_multiple = mclk_mult,
             },
-        .slot_cfg = get_tdm_slot_config(this->i2s_comm_fmt_, bit_width, I2S_SLOT_MODE_STEREO, tdm_mask),
+        .slot_cfg = get_tdm_slot_config(this->i2s_comm_fmt_, bit_width, I2S_SLOT_MODE_STEREO, tx_tdm_mask),
         .gpio_cfg =
             {
                 .mclk = pin_or_nc(this->mclk_pin_),
@@ -860,13 +881,16 @@ bool ESPAudioStack::prepare_i2s_channels_() {
             },
     };
 
-    // Apply slot_bit_width override BEFORE init
+    // Preserve physical frame geometry independently of the sparse masks.
     if (slot_bw != I2S_SLOT_BIT_WIDTH_AUTO) {
-      tdm_cfg.slot_cfg.slot_bit_width = slot_bw;
+      base_tdm_cfg.slot_cfg.slot_bit_width = slot_bw;
     }
+    base_tdm_cfg.slot_cfg.total_slot = this->tdm_total_slots_;
 
     if (this->tx_handle_) {
-      err = i2s_channel_init_tdm_mode(this->tx_handle_, &tdm_cfg);
+      auto tx_tdm_cfg = base_tdm_cfg;
+      tx_tdm_cfg.slot_cfg.slot_mask = tx_tdm_mask;
+      err = i2s_channel_init_tdm_mode(this->tx_handle_, &tx_tdm_cfg);
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to init TX TDM channel: %s", esp_err_to_name(err));
         this->deinit_i2s_();
@@ -876,7 +900,9 @@ bool ESPAudioStack::prepare_i2s_channels_() {
       ESP_LOGD(TAG, "TX TDM channel initialized");
     }
     if (this->rx_handle_) {
-      err = i2s_channel_init_tdm_mode(this->rx_handle_, &tdm_cfg);
+      auto rx_tdm_cfg = base_tdm_cfg;
+      rx_tdm_cfg.slot_cfg.slot_mask = rx_tdm_mask;
+      err = i2s_channel_init_tdm_mode(this->rx_handle_, &rx_tdm_cfg);
       if (err != ESP_OK) {
         ESP_LOGE(TAG, "Failed to init RX TDM channel: %s", esp_err_to_name(err));
         this->deinit_i2s_();
@@ -887,11 +913,13 @@ bool ESPAudioStack::prepare_i2s_channels_() {
     }
 
     if (this->tdm_second_mic_slot_ >= 0) {
-      ESP_LOGD(TAG, "TDM mode: %d slots, mic_slots=[%d,%d], ref_slot=%d, mask=0x%x", this->tdm_total_slots_,
-               this->tdm_mic_slot_, this->tdm_second_mic_slot_, this->tdm_ref_slot_, (unsigned) tdm_mask);
+      ESP_LOGD(TAG, "TDM mode: %d physical slots, mic_slots=[%d,%d], ref_slot=%d, rx_mask=0x%x, tx_mask=0x%x",
+               this->tdm_total_slots_, this->tdm_mic_slot_, this->tdm_second_mic_slot_, this->tdm_ref_slot_,
+               (unsigned) rx_tdm_mask, (unsigned) tx_tdm_mask);
     } else {
-      ESP_LOGD(TAG, "TDM mode: %d slots, mic_slot=%d, ref_slot=%d, mask=0x%x", this->tdm_total_slots_,
-               this->tdm_mic_slot_, this->tdm_ref_slot_, (unsigned) tdm_mask);
+      ESP_LOGD(TAG, "TDM mode: %d physical slots, mic_slot=%d, ref_slot=%d, rx_mask=0x%x, tx_mask=0x%x",
+               this->tdm_total_slots_, this->tdm_mic_slot_, this->tdm_ref_slot_, (unsigned) rx_tdm_mask,
+               (unsigned) tx_tdm_mask);
     }
   } else
 #endif  // SOC_I2S_SUPPORTS_TDM
@@ -1003,10 +1031,7 @@ CodecDevBackend::SampleConfig ESPAudioStack::make_tx_sample_config_() const {
 #if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
   if (this->use_tdm_bus_) {
     cfg.channels = this->tdm_total_slots_;
-    cfg.channel_mask = 0;
-    for (uint8_t i = 0; i < this->tdm_total_slots_; i++) {
-      cfg.channel_mask |= ESP_CODEC_DEV_MAKE_CHANNEL_MASK(i);
-    }
+    cfg.channel_mask = this->tdm_tx_slot_mask_();
     return cfg;
   }
 #endif
@@ -1028,10 +1053,7 @@ CodecDevBackend::SampleConfig ESPAudioStack::make_rx_sample_config_() const {
 #if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
   if (this->use_tdm_bus_) {
     cfg.channels = this->tdm_total_slots_;
-    cfg.channel_mask = 0;
-    for (uint8_t i = 0; i < this->tdm_total_slots_; i++) {
-      cfg.channel_mask |= ESP_CODEC_DEV_MAKE_CHANNEL_MASK(i);
-    }
+    cfg.channel_mask = this->tdm_rx_slot_mask_();
     return cfg;
   }
 #endif

--- a/esphome/components/esp_audio_stack/esp_audio_stack.h
+++ b/esphome/components/esp_audio_stack/esp_audio_stack.h
@@ -433,6 +433,7 @@ class ESPAudioStack final : public Component {
   void set_task_core(int8_t core) { this->task_core_ = core; }
   void set_task_stack_size(uint32_t size) { this->task_stack_size_ = size; }
   void set_dma_desc_num(uint32_t desc_num) { this->dma_desc_num_ = desc_num; }
+  void set_processor_dma_margin(bool enabled) { this->processor_dma_margin_ = enabled; }
   void set_dma_frame_num(uint32_t frame_num) {
     this->dma_frame_num_ = frame_num;
     this->dma_frame_num_configured_ = true;
@@ -459,6 +460,12 @@ class ESPAudioStack final : public Component {
   bool enable_i2s_channels_();
   void close_audio_io_();
   void deinit_i2s_();
+#if SOC_I2S_SUPPORTS_TDM && defined(USE_ESP_AUDIO_STACK_TDM_BUS)
+  uint16_t tdm_rx_slot_mask_() const;
+  uint16_t tdm_tx_slot_mask_() const;
+  static uint8_t tdm_active_slot_count_(uint16_t mask);
+  static uint8_t tdm_packed_slot_index_(uint16_t mask, uint8_t physical_slot);
+#endif
 #ifdef USE_ESP_AUDIO_STACK_HARDWARE_CODEC
   bool setup_codec_backend_(i2s_clock_src_t clk_src);
   CodecDevBackend::SampleConfig make_tx_sample_config_() const;
@@ -493,10 +500,16 @@ class ESPAudioStack final : public Component {
     bool ref_channel_right{false};
     bool correct_dc_offset{false};
     uint8_t tdm_total_slots{0};
+    uint8_t tdm_rx_active_slots{0};
+    uint8_t tdm_tx_active_slots{0};
     uint8_t tdm_mic_slot{0};
     int8_t tdm_second_mic_slot{-1};
     uint8_t tdm_ref_slot{0};
     uint8_t tdm_tx_slot{0};
+    uint8_t tdm_mic_dma_slot{0};
+    int8_t tdm_second_mic_dma_slot{-1};
+    uint8_t tdm_ref_dma_slot{0};
+    uint8_t tdm_tx_dma_slot{0};
     uint8_t speaker_channels{1};
     uint8_t processor_mic_channels{1};
     uint32_t processor_spec_revision{0};
@@ -848,6 +861,7 @@ class ESPAudioStack final : public Component {
   int8_t task_core_{0};        // Core 0: canonical Espressif AEC pattern; -1 = unpinned
   uint32_t task_stack_size_{8192};
   uint32_t dma_desc_num_{6};
+  bool processor_dma_margin_{true};
   uint32_t dma_frame_num_{0};
   bool dma_frame_num_configured_{false};
   bool buffers_in_psram_{false};           // Non-DMA buffers in PSRAM (saves ~15KB internal RAM)

--- a/tests/test_audio_stack_cpp_contract.py
+++ b/tests/test_audio_stack_cpp_contract.py
@@ -30,6 +30,38 @@ def test_tdm_16bit_rx_extracts_only_selected_channels() -> None:
     assert "out[i] = in[i * stride + offset];" in extract
 
 
+def test_tdm_dma_uses_direction_specific_sparse_slot_masks() -> None:
+    cpp = read("esp_audio_stack.cpp")
+    pipeline = read("audio_pipeline.cpp")
+    header = read("esp_audio_stack.h")
+
+    assert "tdm_rx_slot_mask_() const" in header
+    assert "tdm_tx_slot_mask_() const" in header
+    assert "base_tdm_cfg.slot_cfg.total_slot = this->tdm_total_slots_" in cpp
+    assert "tx_tdm_cfg.slot_cfg.slot_mask = tx_tdm_mask" in cpp
+    assert "rx_tdm_cfg.slot_cfg.slot_mask = rx_tdm_mask" in cpp
+    assert "cfg.channel_mask = this->tdm_tx_slot_mask_()" in cpp
+    assert "cfg.channel_mask = this->tdm_rx_slot_mask_()" in cpp
+    assert "ctx.tdm_rx_active_slots" in pipeline
+    assert "ctx.tdm_tx_active_slots" in pipeline
+    assert "ctx.tdm_packed_slot_index_" not in pipeline
+    assert "this->tdm_packed_slot_index_" in pipeline
+
+
+def test_processor_dma_margin_is_an_explicit_backward_compatible_option() -> None:
+    cpp = read("esp_audio_stack.cpp")
+    header = read("esp_audio_stack.h")
+    init = read("__init__.py")
+
+    assert "bool processor_dma_margin_{true}" in header
+    assert "set_processor_dma_margin(bool enabled)" in header
+    assert "this->processor_dma_margin_" in cpp
+    assert "ceil_div_u32(processor_bus_frames * 5U, 4U)" in cpp
+    assert 'CONF_PROCESSOR_DMA_MARGIN = "processor_dma_margin"' in init
+    assert "cv.Optional(CONF_PROCESSOR_DMA_MARGIN, default=True)" in init
+    assert "cv.Optional(CONF_DMA_DESC_NUM, default=6)" in init
+
+
 def test_realtime_audio_loop_has_no_tick_delay_or_effect_allocator() -> None:
     cpp = read("audio_pipeline.cpp")
     alc = cpp[

--- a/tests/test_slot_levels.py
+++ b/tests/test_slot_levels.py
@@ -24,19 +24,24 @@ float compute_rms_dbfs_i32_top16(const int32_t *p,size_t n,size_t stride) {
  double power=0;for(size_t i=0;i<n;++i){double x=p[i*stride]/65536;power+=x*x;}
  return power==0 ? -120 : 10*std::log10(power/n/(32768.0*32768.0));
 }
-struct AudioTaskCtx {bool use_tdm_bus=false;uint8_t tdm_total_slots=4;size_t bus_frame_size=8;unsigned i2s_bps=2;int16_t *rx_buffer;};
+struct AudioTaskCtx {bool use_tdm_bus=false;uint8_t tdm_total_slots=4;uint8_t tdm_rx_active_slots=0;size_t bus_frame_size=8;unsigned i2s_bps=2;int16_t *rx_buffer;};
 struct ESPAudioStack {
  bool tdm_slot_level_sensor_enabled_[8]{};
  std::atomic<float> tdm_slot_level_dbfs_[8]{};
  uint8_t tdm_slot_level_divider_=0;
+ uint16_t tdm_rx_slot_mask_() const {return 0x0D;} // physical slots 0, 2, 3
+ static uint8_t tdm_packed_slot_index_(uint16_t mask,uint8_t physical_slot) {
+  uint16_t lower=physical_slot==0 ? 0 : uint16_t(mask&((1U<<physical_slot)-1U));
+  return __builtin_popcount(unsigned(lower));
+ }
  void update_tdm_slot_levels_(const AudioTaskCtx&);
 };
 '''
     checks = r'''
 int main(){
- for(bool tdm : {false,true}) for(unsigned width : {2,4}) {
-  ESPAudioStack stack;AudioTaskCtx ctx;ctx.use_tdm_bus=tdm;ctx.i2s_bps=width;
-  int16_t raw[32]{};int32_t wide[32]{};unsigned stride=tdm ? 4 : 2;
+ for(unsigned width : {2,4}) {
+  ESPAudioStack stack;AudioTaskCtx ctx;ctx.i2s_bps=width;
+  int16_t raw[32]{};int32_t wide[32]{};unsigned stride=2;
   stack.tdm_slot_level_sensor_enabled_[0]=true;stack.tdm_slot_level_sensor_enabled_[1]=true;
   for(unsigned i=0;i<8;++i){raw[i*stride]=8192;raw[i*stride+1]=16384;}
   for(unsigned i=0;i<32;++i)wide[i]=int32_t(raw[i])*65536;
@@ -45,6 +50,19 @@ int main(){
   assert(std::abs(stack.tdm_slot_level_dbfs_[0]+12.0412f)<0.01f);
   assert(std::abs(stack.tdm_slot_level_dbfs_[1]+6.0206f)<0.01f);
   assert(stack.tdm_slot_level_dbfs_[2]==0); // Unrequested slots are not measured.
+ }
+ for(unsigned width : {2,4}) {
+  ESPAudioStack stack;AudioTaskCtx ctx;ctx.use_tdm_bus=true;ctx.i2s_bps=width;ctx.tdm_rx_active_slots=3;
+  int16_t raw[32]{};int32_t wide[32]{};
+  for(unsigned slot=0;slot<4;++slot)stack.tdm_slot_level_sensor_enabled_[slot]=true;
+  for(unsigned i=0;i<8;++i){raw[i*3]=8192;raw[i*3+1]=16384;raw[i*3+2]=24576;}
+  for(unsigned i=0;i<32;++i)wide[i]=int32_t(raw[i])*65536;
+  ctx.rx_buffer=width==2 ? raw : reinterpret_cast<int16_t*>(wide);
+  for(unsigned i=0;i<8;++i)stack.update_tdm_slot_levels_(ctx);
+  assert(std::abs(stack.tdm_slot_level_dbfs_[0]+12.0412f)<0.01f);
+  assert(stack.tdm_slot_level_dbfs_[1]==-120); // Disabled physical slot has no DMA sample.
+  assert(std::abs(stack.tdm_slot_level_dbfs_[2]+6.0206f)<0.01f);
+  assert(std::abs(stack.tdm_slot_level_dbfs_[3]+2.4988f)<0.01f);
  }
 }
 '''


### PR DESCRIPTION
## Summary

This changes TDM mode so RX and TX DMA transfer only the slots used by each direction while preserving `tdm_total_slots` as the physical frame geometry. It also adds an opt-out for the automatic 25% processor-frame DMA margin on memory-constrained targets.

The motivating configuration is the Waveshare ESP32-S3 Audio Board:

```yaml
esp_audio_stack:
  sample_rate: 48000
  output_sample_rate: 16000
  bits_per_sample: 32
  slot_bit_width: 32

  tdm_total_slots: 4
  tdm_mic_slots: [0, 2]
  use_tdm_reference: true
  tdm_ref_slot: 1
  tdm_tx_slot: 0

  dma_desc_num: 12
  processor_dma_margin: false
```

The codec requires the complete four-slot, 32-bit physical frame at 48 kHz, but RX consumes only slots 0/1/2 and TX only slot 0. Moving all four slots through both DMA directions consumes too much internal DMA-capable RAM on the ESP32-S3.

## Observed problem and reproduction

With the existing all-slot DMA layout:

1. Configure the four-slot TDM bus above with dual microphones, the playback reference and a 16 kHz AFE output.
2. Build and run it on the Waveshare ESP32-S3 Audio Board.
3. At 48 kHz, the full 32-bit layout exceeds the practical descriptor/memory budget. Reduced-width experiments either broke wake-word detection or produced missing/incorrect playback, so changing the codec framing was not viable.

After using sparse per-direction slot masks, the normal automatic 25% processor margin selected 15 descriptors of 256 frames. Only about 871 bytes of DMA-capable memory remained after I2S enable and wake-word recognition did not work. Twelve descriptors hold exactly one 3072-frame/64 ms processor quantum and left approximately 12.7 KiB of DMA-capable memory.

## Implementation

- Derive independent RX and TX slot masks from the configured mic, reference and playback slots.
- Keep `slot_cfg.total_slot = tdm_total_slots`, preserving the physical BCLK/WS frame.
- Pass the independent masks to the ESP-IDF RX/TX TDM channel configurations and codec sample configurations.
- Account for packed active slots in DMA sizing, buffer allocation, rate conversion, TX formatting and slot diagnostics.
- Map configured physical slot numbers to their packed DMA positions.
- Add `processor_dma_margin` (default: `true`). Setting it to `false` omits only the extra 25% margin; the component still expands the DMA queue to at least one complete processor frame.

The existing `dma_desc_num` semantics are unchanged, and existing configurations retain the current margin by default.

## Validation

- `uv run pytest -q`: **62 passed**.
- Built with ESPHome 2026.8.2 for an ESP32-S3 using ESP-IDF.
- Flashed and exercised on the Waveshare ESP32-S3 Audio Board.
- Verified both physical microphones and the analog playback-reference input through the 48 kHz bus and 16 kHz dual-mic AFE path.
- Verified wake-word detection, VAD-completed capture, a complete Home Assistant Assist request and correctly pitched/speeded TTS playback.
- Verified startup and wake chimes at the correct speed and pitch.
- Re-tested after separating `processor_dma_margin` from `dma_desc_num`; the 12-descriptor configuration remained functional end to end.

## Scope and tradeoffs

This does not change the configured physical TDM layout or sample rate. It reduces DMA storage only for inactive slots. The optional margin control is intended for measured, memory-constrained configurations; retaining the default margin remains the safer general setting.
